### PR TITLE
Add USW custom configuration for IPTV

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,15 @@ Determining cause and solutions:
 
     Use your favorite search engine and the links below to read up about possible symptoms, causes and solutions.
 
+## Unify Switch Configuration
+
+IPTV requires changes to the default **USW** IGMP configuration.
+* Disable IGMP header validation
+* Enable IGMP fast leave
+
+Use the steps above, used to deploy the `config.gateway.json` file, to deploy the `config.properties` file, then reprovision the **USW**s
+The configuration is for VLAN 1, update the VLAN ID to the VLAN for IPTV on you network
+
 ### Networking issues
 Possible networking issues:
 * Slow network (latency)

--- a/config.properties
+++ b/config.properties
@@ -1,0 +1,3 @@
+# KPN/XS4All IPTV IGMP Configuration
+config.system_cfg.1=switch.igmp.header_checking=false
+config.system_cfg.2=switch.vlan.1.igmp_fastleave=true

--- a/debug/USW.md
+++ b/debug/USW.md
@@ -1,0 +1,64 @@
+# Uinify Managed Switch (USW)
+
+## Introduction
+This document describes how to validate the switch' IGMP configuration
+
+## Validate Switch Provisioning
+
+1. Login 
+
+    Login into the switch using the debug terminal from the management interface or use `ssh`.
+
+2. Verify provisionming configuration file
+
+    The end of the `/etc/system.cfg` contains the custom provisioned data from the `config.properties` file on the controller. At the end of the file in the `#misc` section you will see the provisioned entries
+
+    ```
+    # misc
+    switch.igmp.header_checking=false
+    switch.vlan.1.igmp_fastleave=true
+    ```
+
+# Validate the Switch Configuration
+
+1. Login
+
+    Login into the switch using the debug terminal from the management interface or use `ssh`.
+
+2. Change to switch managment mode
+
+    `telnet localhost`
+
+3. Enable switch management mode
+
+    `enable`
+
+4. Enter VLAN mode
+
+    `vlan database`
+
+5. Show IGMP configuration
+
+    `show igmpsnooping`
+
+    The output of the command shows that IGMP header validation is disabled:
+    ```
+    Admin Mode..................................... Enable
+    Multicast Control Frame Count.................. 584799
+    IGMP header validation......................... Disabled
+    Interfaces Enabled for IGMP Snooping........... None
+    VLANs enabled for IGMP snooping................ 1
+    ```
+    
+    `show igmpsnooping 1`
+
+    The output of the command shows that Fast Leave Mode is enabled for VLAN 1:
+    ```
+    VLAN ID........................................ 1
+    IGMP Snooping Admin Mode....................... Enabled
+    Fast Leave Mode................................ Enabled
+    Group Membership Interval (secs)............... 260
+    Max Response Time (secs)....................... 10
+    Multicast Router Expiry Time (secs)............ 0
+    Report Suppression Mode........................ Disabled
+    ```


### PR DESCRIPTION
The default USW configuration is not compatible with KPN/XS4All IPTV.

As stated here [Instellingen voor andere Modems](https://www.xs4all.nl/service/diensten/internet/installeren/modem-instellen/hoe-kan-ik-een-ander-modem-dan-fritzbox-instellen.htm) The following changes are required for Unify switched
IPTV requires changes to the default **USW** IGMP configuration.
* Disable IGMP header validation
* Enable IGMP fast leave

This pull request implements these changes for the **USW** with IPTV on VLAN 1.