### PR TITLE
Updates to user-id and VLANs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Notes:
 Let's get started.
 
 Pull the `config.gateway.json`  from the repo and change the following:
-1. Replace the MAC address placeholder `xx-xx-xx-xx-xx-xx` with the real MAC address of the USG (see *Setup basic Internet, step 2*).
-2. Adjust the IP ranges / DHCP ranges to you're liking (currently `192.168.100.1/24`) but they can be any range as long as they do not overlap public IP spaces (duh) and the IPTV ranges KPN uses.
-3. Save the file (using UNIX file format)
-4. (optional) Use an online JSON validator to check of you have created / not corrupted the JSON file.
+1. Adjust the IP ranges / DHCP ranges to you're liking (currently `192.168.100.1/24`) but they can be any range as long as they do not overlap public IP spaces (duh) and the IPTV ranges KPN uses.
+2. Save the file (using UNIX file format)
+3. (optional) Use an online JSON validator to check of you have created / not corrupted the JSON file.
+4. (optional) If you want to put your decoders into their own VLAN make sure to first read the VLANs section before continuing.
 
 ### 3. Publish and provision the configuration
 In order for the file to by applied to the USG you need to upload it to the **Unifi Controller** from there you can provision it to the USG.
@@ -133,6 +133,39 @@ The routed IP network sometimes changes, therefore the next-hop settings for rou
 Wait for it.... you're done. The Internet and IPTV should be working. Test you're IPTV by rebooting the decoders and see if they come back online. If not... read below.
 
 In case the USG or IPTV doesn't work, please consult the section "Troubleshooting" below.
+
+## VLANs
+
+If you are using VLANs and have issues with the IPTV having hickups or being frozen you can try to change the config as follows:
+
+At the "igmp-proxy" section replace "eth1" with "eth.{vlan}" where {vlan} would be the VLAN where your decoders are in. 
+
+```
+"eth1.100": {
+    "alt-subnet": [
+        "0.0.0.0/0"
+    ],
+    "role": "downstream",
+    "threshold": "1"
+}
+```
+
+To prevent the IPTV from flooding other network interfaces it's best to explicitly disable the proxy for these interfaces:
+
+```
+"eth1": {
+    "role": "disabled",
+    "threshold": "1"
+},
+"eth1.200": {
+    "role": "disabled",
+    "threshold": "1"
+},
+"eth1.300": {
+    "role": "disabled",
+    "threshold": "1"
+}
+```
 
 ## Troubleshooting
 This section describes some of the most commmon issues and (possible) solutions. If these tips don't help you, read the articles mentioned below. Further sources of wisdom include the UBNT, Tweakers.net and KPN fora.

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -1,211 +1,211 @@
 {
-        "interfaces": {
-                "ethernet": {
-                        "eth0": {
-                                "description": "eth0 - FTTH",
-                                "duplex": "auto",
-                                "speed": "auto",
-                                "vif": {
-                                        "4": {
-                                                "address": [
-                                                    "dhcp"
-                                                ],
-                                                "description": "eth0.4 - IPTV",
-                                                "dhcp-options": {
-                                                        "client-option": [
-                                                                "send vendor-class-identifier &quot;IPTV_RG&quot;;",
-                                                                "request subnet-mask, routers, rfc3442-classless-static-routes;"
-                                                        ],
-                                                        "default-route": "no-update",
-                                                        "default-route-distance": "210",
-                                                        "name-server": "update"
-                                                }
-                                                ,"ip": {
-                                                        "source-validation": "loose"
-                                                    }
-                                        },
-                                        "6": {
-                                                "description": "eth0.6 - Internet",
-                                                "firewall": {
-                                                        "in": {
-                                                                "name": "WAN_IN"
-                                                        },
-                                                        "local": {
-                                                                "name": "WAN_LOCAL"
-                                                        },
-                                                        "out": {
-                                                                "name": "WAN_OUT"
-                                                        }
-                                                },
-                                                "pppoe": {
-                                                        "2": {
-                                                                "default-route": "auto",
-                                                                "firewall": {
-                                                                        "in": {
-                                                                                "name": "WAN_IN"
-                                                                        },
-                                                                        "local": {
-                                                                                "name": "WAN_LOCAL"
-                                                                        },
-                                                                        "out": {
-                                                                                "name": "WAN_OUT"
-                                                                        }
-                                                                },
-                                                                "mtu": "1492",
-                                                                "name-server": "none",
-                                                                "password": "kpn",
-                                                                "user-id": "xx-xx-xx-xx-xx-xx@internet"
-                                                        }
-                                                }
-                                        }
-                                }
-                        },
-                        "eth1": {
-                                "description": "eth1 - LAN",
-                                "address": [
-                                        "192.168.100.1/24"
-                                ],
-                                "duplex": "auto",
-                                "firewall": {
-                                        "in": {
-                                                "name": "LAN_IN"
-                                        },
-                                        "local": {
-                                                "name": "LAN_LOCAL"
-                                        },
-                                        "out": {
-                                                "name": "LAN_OUT"
-                                        }
-                                },
-                                "speed": "auto"
-                        },
-                        "eth2": {
-                                "disable": "''",
-                                "duplex": "auto",
-                                "speed": "auto"
-                        }
+  "interfaces": {
+    "ethernet": {
+      "eth0": {
+        "description": "eth0 - FTTH",
+        "duplex": "auto",
+        "speed": "auto",
+        "vif": {
+          "4": {
+            "address": [
+              "dhcp"
+            ],
+            "description": "eth0.4 - IPTV",
+            "dhcp-options": {
+              "client-option": [
+                "send vendor-class-identifier &quot;IPTV_RG&quot;;",
+                "request subnet-mask, routers, rfc3442-classless-static-routes;"
+              ],
+              "default-route": "no-update",
+              "default-route-distance": "210",
+              "name-server": "update"
+            },
+            "ip": {
+              "source-validation": "loose"
+            }
+          },
+          "6": {
+            "description": "eth0.6 - Internet",
+            "firewall": {
+              "in": {
+                "name": "WAN_IN"
+              },
+              "local": {
+                "name": "WAN_LOCAL"
+              },
+              "out": {
+                "name": "WAN_OUT"
+              }
+            },
+            "pppoe": {
+              "2": {
+                "default-route": "auto",
+                "firewall": {
+                  "in": {
+                    "name": "WAN_IN"
+                  },
+                  "local": {
+                    "name": "WAN_LOCAL"
+                  },
+                  "out": {
+                    "name": "WAN_OUT"
+                  }
                 },
-                "loopback": {
-                        "lo": "''"
-                }
-        },
-        "protocols": {
-                "igmp-proxy": {
-                    "disable-quickleave": "''",
-                    "interface": {
-                        "eth0": {
-                          "role": "disabled",
-                          "threshold": "1"
-                        },
-                        "eth0.4": {
-                            "alt-subnet": [
-                                "0.0.0.0/0"
-                            ],
-                            "role": "upstream",
-                            "threshold": "1"
-                        },
-                        "eth1": {
-                          "alt-subnet": [
-                              "0.0.0.0/0"
-                          ],
-                          "role": "downstream",
-                          "threshold": "1"
-                        },
-                         "pppoe2": {
-                          "role": "disabled",
-                          "threshold": "1"
-                        }
-                    }
-                },
-                "static": {
-                        "interface-route": {
-                                "0.0.0.0/0": {
-                                        "next-hop-interface": {
-                                                "pppoe2": {
-                                                        "distance": "1"
-                                                }
-                                        }
-                                }
-                        },
-                        "route": {
-                                "213.75.112.0/21": {
-                                        "next-hop": {
-                                                "10.213.96.1": "''"
-                                        }
-                                }
-                        }
-                }
-        },
-        "port-forward": {
-                "auto-firewall": "enable",
-                "hairpin-nat": "enable",
-                "lan-interface": [
-                        "eth1"
-                ],
-                "wan-interface": "pppoe2"
-        },
-        "system": {
-                "task-scheduler": {
-                        "task": {
-                                "iptv": {
-                                        "executable": {
-                                                "path": "/config/scripts/post-config.d/update_iptv_route.sh"
-                                        },
-                                        "interval": "15m"
-                                }
-                        }
-                }
-        },
-        "service": {
-                "nat": {
-                        "rule": {
-                              "5000": {
-                                        "description": "MASQ corporate_network to IPTV network",
-                                        "destination": {
-                                                "address": "213.75.112.0/21"
-                                        },
-                                        "log": "disable",
-                                        "outbound-interface": "eth0.4",
-                                        "protocol": "all",
-                                        "type": "masquerade"
-                              },
-                              "6001": {
-                                        "description": "MASQ corporate_network to WAN",
-                                        "log": "disable",
-                                        "outbound-interface": "pppoe2",
-                                        "protocol": "all",
-                                        "source": {
-                                                "group": {
-                                                        "network-group": "corporate_network"
-                                                }
-                                        },
-                                        "type": "masquerade"
-                                },
-                                "6002": {
-                                        "description": "MASQ remote_user_vpn_network to WAN",
-                                        "log": "disable",
-                                        "outbound-interface": "pppoe2",
-                                        "protocol": "all",
-                                        "source": {
-                                                "group": {
-                                                        "network-group": "remote_user_vpn_network"
-                                                }
-                                        },
-                                        "type": "masquerade"
-                                },
-                                "6003": {
-                                        "description": "MASQ guest_network to WAN",
-                                        "log": "disable",
-                                        "outbound-interface": "pppoe2",
-                                        "protocol": "all",
-                                        "source": {
-                                                "group": {
-                                                        "network-group": "guest_network"
-                                                }
-                                        },
-                                        "type": "masquerade"
-                                }
-                        }
-                }
+                "mtu": "1492",
+                "name-server": "none",
+                "password": "kpn",
+                "user-id": "kpn"
+              }
+            }
+          }
         }
+      },
+      "eth1": {
+        "description": "eth1 - LAN",
+        "address": [
+          "192.168.100.1/24"
+        ],
+        "duplex": "auto",
+        "firewall": {
+          "in": {
+            "name": "LAN_IN"
+          },
+          "local": {
+            "name": "LAN_LOCAL"
+          },
+          "out": {
+            "name": "LAN_OUT"
+          }
+        },
+        "speed": "auto"
+      },
+      "eth2": {
+        "disable": "''",
+        "duplex": "auto",
+        "speed": "auto"
+      }
+    },
+    "loopback": {
+      "lo": "''"
+    }
+  },
+  "protocols": {
+    "igmp-proxy": {
+      "disable-quickleave": "''",
+      "interface": {
+        "eth0": {
+          "role": "disabled",
+          "threshold": "1"
+        },
+        "eth0.4": {
+          "alt-subnet": [
+            "0.0.0.0/0"
+          ],
+          "role": "upstream",
+          "threshold": "1"
+        },
+        "eth1": {
+          "alt-subnet": [
+            "0.0.0.0/0"
+          ],
+          "role": "downstream",
+          "threshold": "1"
+        },
+        "pppoe2": {
+          "role": "disabled",
+          "threshold": "1"
+        }
+      }
+    },
+    "static": {
+      "interface-route": {
+        "0.0.0.0/0": {
+          "next-hop-interface": {
+            "pppoe2": {
+              "distance": "1"
+            }
+          }
+        }
+      },
+      "route": {
+        "213.75.112.0/21": {
+          "next-hop": {
+            "10.213.96.1": "''"
+          }
+        }
+      }
+    }
+  },
+  "port-forward": {
+    "auto-firewall": "enable",
+    "hairpin-nat": "enable",
+    "lan-interface": [
+      "eth1"
+    ],
+    "wan-interface": "pppoe2"
+  },
+  "system": {
+    "task-scheduler": {
+      "task": {
+        "iptv": {
+          "executable": {
+            "path": "/config/scripts/post-config.d/update_iptv_route.sh"
+          },
+          "interval": "15m"
+        }
+      }
+    }
+  },
+  "service": {
+    "nat": {
+      "rule": {
+        "5000": {
+          "description": "MASQ corporate_network to IPTV network",
+          "destination": {
+            "address": "213.75.112.0/21"
+          },
+          "log": "disable",
+          "outbound-interface": "eth0.4",
+          "protocol": "all",
+          "type": "masquerade"
+        },
+        "6001": {
+          "description": "MASQ corporate_network to WAN",
+          "log": "disable",
+          "outbound-interface": "pppoe2",
+          "protocol": "all",
+          "source": {
+            "group": {
+              "network-group": "corporate_network"
+            }
+          },
+          "type": "masquerade"
+        },
+        "6002": {
+          "description": "MASQ remote_user_vpn_network to WAN",
+          "log": "disable",
+          "outbound-interface": "pppoe2",
+          "protocol": "all",
+          "source": {
+            "group": {
+              "network-group": "remote_user_vpn_network"
+            }
+          },
+          "type": "masquerade"
+        },
+        "6003": {
+          "description": "MASQ guest_network to WAN",
+          "log": "disable",
+          "outbound-interface": "pppoe2",
+          "protocol": "all",
+          "source": {
+            "group": {
+              "network-group": "guest_network"
+            }
+          },
+          "type": "masquerade"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Set user-id to "kpn", update README.md to no longer refer to user-id, add section about VLANs.

I also took the liberty to format the config.gateway.json to use 2 spaces of indentation instead of 8.